### PR TITLE
Reroll will accept array of dice objects, remove the check for groupId === string

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Frank Ali"
 	},
 	"description": "A 3D environment for rolling game dice",
-	"version": "0.4.30",
+	"version": "0.4.20",
 	"keywords": [
 		"3D",
 		"dice",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Frank Ali"
 	},
 	"description": "A 3D environment for rolling game dice",
-	"version": "0.4.20",
+	"version": "0.4.30",
 	"keywords": [
 		"3D",
 		"dice",

--- a/src/World.js
+++ b/src/World.js
@@ -313,28 +313,31 @@ class World {
 	// accepts array of objects eg: [{sides:int, qty:int, mods:[]}]
 	// accepts object {sides:int, qty:int}
 	createNotationArray(notation){
+		const notation = Array.isArray( input ) ? input : [ input ]
 		let parsedNotation = []
 
-		if(typeof notation === 'string') {
-			parsedNotation.push(this.parse(notation))
+		const verifyObject = ( object ) => {
+			const checkSidesAndQty =  object.sides && object.qty ? true : false
+	
+			if ( checkSidesAndQty ) {
+				return true
+			} else {
+				const err = "Roll notation is missing sides and/or qty"
+				throw new Error(err);
+			}
 		}
+	
 
 		// notation is an array of strings or objects
-		if(Array.isArray(notation)) {
-			notation.forEach(roll => {
-				// if notation is an array of strings
-				if(typeof roll === 'string') {
-					parsedNotation.push(this.parse(roll))
-				}
-				else {
-					// TODO: ensure that there is a 'sides' and 'qty' value on the object - required for making a roll
-					parsedNotation.push(roll)
-				}
-			})
-		} else if(typeof notation === 'object'){
-			// TODO: ensure that there is a 'sides' and 'qty' value on the object - required for making a roll
-			parsedNotation.push(notation)
-		}
+		notation.forEach(roll => {
+			// if notation is an array of strings
+			if ( typeof roll === 'string' ) {
+				parsedNotation.push( parseStringNotation( roll ) )
+			} else if ( typeof notation === 'object' ) {
+				verifyObject( roll ) && parsedNotation.push( roll )
+			}
+		})
+
 
 		return parsedNotation
 	}

--- a/src/World.js
+++ b/src/World.js
@@ -199,9 +199,8 @@ class World {
 
 	// add a die to another group. groupId should be included
   add(notation, groupId, theme) {
-		if(typeof groupId === 'string' || theme) {
-			this.config.theme = theme
-		}
+		if(theme) this.config.theme = theme
+
 		let parsedNotation = this.createNotationArray(notation)
 		this.#makeRoll(parsedNotation, groupId)
 
@@ -209,14 +208,21 @@ class World {
 		return this
   }
 
-	reroll(die) {
+	reroll(dice) {
 		// TODO: add hide if you want to keep the die result for an external parser
 		// TODO: reroll group
-		// TODO: reroll array
-		this.remove(die)
-		die.qty = 1
-		this.add(die, die.groupId)
+		if ( Array.isArray(dice) ) {
+			const groupId = dice[0].groupId
+			const addQty = dice.map(r => ( {...r, qty: 1} ) )
 
+			dice.forEach(r =>  this.remove( r ) )
+
+			this.add(addQty, groupId)
+		} else {
+			const addDie = { ...dice, qty: 1 }
+			this.remove( dice )
+			this.add(addDie, addDie.groupId)
+		}
 		// make this method chainable
 		return this
 	}

--- a/src/World.js
+++ b/src/World.js
@@ -211,18 +211,13 @@ class World {
 	reroll(dice) {
 		// TODO: add hide if you want to keep the die result for an external parser
 		// TODO: reroll group
-		if ( Array.isArray(dice) ) {
-			const groupId = dice[0].groupId
-			const addQty = dice.map(r => ( {...r, qty: 1} ) )
-
-			dice.forEach(r =>  this.remove( r ) )
-
-			this.add(addQty, groupId)
-		} else {
-			const addDie = { ...dice, qty: 1 }
-			this.remove( dice )
-			this.add(addDie, addDie.groupId)
-		}
+		const rollArray = Array.isArray(dice) ? dice : [dice]
+		const groupId = rollArray[0].groupId
+		const addQty = rollArray.map(r => ( {...r, qty: 1} ) )
+		
+		rollArray.forEach(r =>  this.remove( r ) )
+	
+		this.add(addQty, groupId)
 		// make this method chainable
 		return this
 	}

--- a/src/World.js
+++ b/src/World.js
@@ -332,7 +332,7 @@ class World {
 		notation.forEach(roll => {
 			// if notation is an array of strings
 			if ( typeof roll === 'string' ) {
-				parsedNotation.push( parse( roll ) )
+				parsedNotation.push( this.parse( roll ) )
 			} else if ( typeof notation === 'object' ) {
 				verifyObject( roll ) && parsedNotation.push( roll )
 			}

--- a/src/World.js
+++ b/src/World.js
@@ -312,7 +312,7 @@ class World {
 	// accepts array of notations eg: ['4d6','2d10']
 	// accepts array of objects eg: [{sides:int, qty:int, mods:[]}]
 	// accepts object {sides:int, qty:int}
-	createNotationArray(notation){
+	createNotationArray(input){
 		const notation = Array.isArray( input ) ? input : [ input ]
 		let parsedNotation = []
 
@@ -332,7 +332,7 @@ class World {
 		notation.forEach(roll => {
 			// if notation is an array of strings
 			if ( typeof roll === 'string' ) {
-				parsedNotation.push( parseStringNotation( roll ) )
+				parsedNotation.push( parse( roll ) )
 			} else if ( typeof notation === 'object' ) {
 				verifyObject( roll ) && parsedNotation.push( roll )
 			}


### PR DESCRIPTION
Allow reroll to accept an array of dice objects

Remove the groupId string check from issues #5 

createNotationArray simplified the code. It checks if the parameter is an array and if not makes it one. This makes the logic easier. Also completed the TODO to check for qty & sides. I wrote tests for this before refactoring. All are green.