### PR TITLE
Internal data rework

### DIFF
--- a/src/World.js
+++ b/src/World.js
@@ -137,9 +137,9 @@ class World {
 			this.onRollComplete(this.getRollResults())
 		}
 
-		this.#DiceWorld.onDieRemoved = (die) => {
+		this.#DiceWorld.onDieRemoved = (rollId) => {
 			// get die information from cache
-			die = this.rollDiceData[die.rollId]
+			let die = this.rollDiceData[rollId]
 			const collection = this.rollCollectionData[die.removeCollectionId]
 			collection.completedRolls++
 
@@ -308,11 +308,12 @@ class World {
 			// add the collectionId to the die so it can be looked up in the callback
 			this.rollDiceData[die.rollId].removeCollectionId = collectionId
 			// assign the id for this die from our cache - required for removal
-			die.id = this.rollDiceData[die.rollId].id
-			// remove the die from the render
-			this.#DiceWorld.remove(die)
+			// die.id = this.rollDiceData[die.rollId].id - note: can appear in async roll result data if attached to die object
+			let id = this.rollDiceData[die.rollId].id
+			// remove the die from the render - don't like having to pass two ids. rollId is passed over just so it can be passed back for callback
+			this.#DiceWorld.remove({id,rollId: die.rollId})
 			// remove the die from the physics bodies
-			this.#DiceWorker.postMessage({action: "removeDie", id: die.id})
+			this.#DiceWorker.postMessage({action: "removeDie", id })
 		})
 
 		return this.rollCollectionData[collectionId].promise

--- a/src/World.js
+++ b/src/World.js
@@ -238,7 +238,7 @@ class World {
 	}
 
 	// TODO: pass data with roll - such as roll name. Passed back at the end in the results
-	roll(notation, theme) {
+	roll(notation, {theme = undefined} = {}) {
 		// note: to add to a roll on screen use .add method
 		// reset the offscreen worker and physics worker with each new roll
 		this.clear()
@@ -257,7 +257,7 @@ class World {
 		return this.rollCollectionData[collectionId].promise
 	}
 
-  add(notation, theme) {
+  add(notation, {theme = undefined} = {}) {
 
 		const collectionId = this.#collectionIndex++
 
@@ -274,7 +274,7 @@ class World {
 		return this.rollCollectionData[collectionId].promise
   }
 
-	reroll(notation, options = {remove: false, hide: false}) {
+	reroll(notation, {remove = false, hide = false} = {}) {
 		// TODO: add hide if you want to keep the die result for an external parser
 
 		// ensure notation is an array
@@ -283,15 +283,15 @@ class World {
 		// destructure out 'sides', 'theme', 'groupId', 'rollId' - basically just getting rid of value - could do ({value, ...rest}) => rest
 		const cleanNotation = rollArray.map(({value, ...rest}) => rest)
 
-		if(options.remove === true){
-			this.remove(cleanNotation, options.hide)
+		if(remove === true){
+			this.remove(cleanNotation, {hide})
 		}
 
 		// .add will return a promise that will then be returned here
 		return this.add(cleanNotation)
 	}
 
-	remove(notation, hide = false) {
+	remove(notation, {hide = false} = {}) {
 		// ensure notation is an array
 		const rollArray = Array.isArray(notation) ? notation : [notation]
 

--- a/src/World.js
+++ b/src/World.js
@@ -481,7 +481,6 @@ class World {
 		const rollGroup = this.rollGroupData[groupId]
 		// turn object into an array
 		const rollsArray = Object.values(rollGroup.rolls).map(({collectionId, id, ...rest}) => rest)
-		rollsArray.sort((a,b) => a.rollId.toString() > b.rollId.toString() ? 1 : -1)
 		// add up the values
 		// some dice may still be rolling, should this be a promise?
 		// if dice are still rolling in the group then the value is undefined - hence the isNaN check

--- a/src/World.js
+++ b/src/World.js
@@ -478,7 +478,12 @@ class World {
 		// turn object into an array
 		const rollsArray = Object.values(rollGroup.rolls).map(roll => roll)
 		// add up the values
-		let value = rollsArray.reduce((val,roll) => val + roll.value,0)
+		// some dice may still be rolling, should this be a promise?
+		// if dice are still rolling in the group then the value is undefined - hence the isNaN check
+		let value = rollsArray.reduce((val,roll) => {
+			const rollVal = isNaN(roll.value) ? 0 : roll.value
+			return val + rollVal
+		},0)
 		// add the modifier
 		value += rollGroup.modifier ? rollGroup.modifier : 0
 		// return the value and the rollsArray

--- a/src/World.js
+++ b/src/World.js
@@ -33,6 +33,7 @@ class World {
 	diceWorkerInit
 	onDieComplete = () => {}
 	onRollComplete = () => {}
+	onRemoveComplete = () => {}
 
   constructor(container, options = {}){
 		// extend defaults with options
@@ -128,7 +129,8 @@ class World {
 			}
 
 			// trigger callback passing individual die result
-			this.onDieComplete(die)
+			const {collectionId, id, ...returnDie} = this.rollDiceData[die.rollId]
+			this.onDieComplete(returnDie)
 		}
 		this.#DiceWorld.onRollComplete = () => {
 			// trigger callback passing the roll results
@@ -158,6 +160,8 @@ class World {
 			if(collection.completedRolls == collection.rolls.length) {
 				collection.resolve(Object.values(collection.rolls).map(({id, ...rest}) => rest))
 			}
+			const {collectionId, id, removeCollectionId, ...returnDie} = die
+			this.onRemoveComplete(returnDie)
 		}
 
     // initialize the AmmoJS physics worker
@@ -476,7 +480,8 @@ class World {
 		// console.log('groupId', groupId)
 		const rollGroup = this.rollGroupData[groupId]
 		// turn object into an array
-		const rollsArray = Object.values(rollGroup.rolls).map(roll => roll)
+		const rollsArray = Object.values(rollGroup.rolls).map(({collectionId, id, ...rest}) => rest)
+		rollsArray.sort((a,b) => a.rollId.toString() > b.rollId.toString() ? 1 : -1)
 		// add up the values
 		// some dice may still be rolling, should this be a promise?
 		// if dice are still rolling in the group then the value is undefined - hence the isNaN check

--- a/src/components/offscreenCanvas.worker.js
+++ b/src/components/offscreenCanvas.worker.js
@@ -249,10 +249,10 @@ const _add = async (options) => {
 
 }
 
-const remove = (die) => {
+const remove = (data) => {
 	// TODO: test this with exploding dice
 	// check if this is d100 and remove associated d10 first
-	const dieData = dieCache[die.id]
+	const dieData = dieCache[data.id]
 	if(dieData.hasOwnProperty('d10Instance')){
 		dieCache[dieData.d10Instance.id].mesh.dispose()
 		delete dieCache[dieData.d10Instance.id]
@@ -266,14 +266,14 @@ const remove = (die) => {
 	// remove die
 	dieData.mesh.dispose()
 	// delete entry
-	delete dieCache[die.id]
+	delete dieCache[data.id]
 	// decrement count
 	sleeperCount--
 
 	// step the animation forward
 	scene.render()
 
-	self.postMessage({action:"die-removed", die})
+	self.postMessage({action:"die-removed", rollId: data.rollId})
 }
 
 const updatesFromPhysics = (buffer) => {

--- a/src/components/offscreenCanvas.worker.js
+++ b/src/components/offscreenCanvas.worker.js
@@ -260,6 +260,8 @@ const remove = (data) => {
 
 	// step the animation forward
 	scene.render()
+
+	self.postMessage({action:"die-removed", die: data})
 }
 
 const updatesFromPhysics = (buffer) => {
@@ -330,7 +332,8 @@ const handleAsleep = async (die) => {
 			self.postMessage({action:"roll-result", die: {
 				groupId: d100.config.groupId,
 				rollId: d100.config.rollId,
-				id: d100.id,
+				collectionId: die.config.collectionId,
+				// id: d100.id,
 				result : d100.result
 			}})
 		}
@@ -342,7 +345,8 @@ const handleAsleep = async (die) => {
 		self.postMessage({action:"roll-result", die: {
 			groupId: die.config.groupId,
 			rollId: die.config.rollId,
-			id: die.id,
+			collectionId: die.config.collectionId,
+			// id: die.id,
 			result: die.result
 		}})
 	}

--- a/src/components/offscreenCanvas.worker.js
+++ b/src/components/offscreenCanvas.worker.js
@@ -249,19 +249,31 @@ const _add = async (options) => {
 
 }
 
-const remove = (data) => {
+const remove = (die) => {
 	// TODO: test this with exploding dice
+	// check if this is d100 and remove associated d10 first
+	const dieData = dieCache[die.id]
+	if(dieData.hasOwnProperty('d10Instance')){
+		dieCache[dieData.d10Instance.id].mesh.dispose()
+		delete dieCache[dieData.d10Instance.id]
+		physicsWorkerPort.postMessage({
+      action: "removeDie",
+			id: dieData.d10Instance.id
+    })
+		sleeperCount--
+	}
+
 	// remove die
-	dieCache[data.id].mesh.dispose()
+	dieData.mesh.dispose()
 	// delete entry
-	delete dieCache[data.id]
+	delete dieCache[die.id]
 	// decrement count
 	sleeperCount--
 
 	// step the animation forward
 	scene.render()
 
-	self.postMessage({action:"die-removed", die: data})
+	self.postMessage({action:"die-removed", die})
 }
 
 const updatesFromPhysics = (buffer) => {

--- a/src/components/physics.worker.js
+++ b/src/components/physics.worker.js
@@ -54,7 +54,7 @@ self.onmessage = (e) => {
 			clearDice(e.data)
       break
 		case "removeDie":
-			removeDie(e.data)
+			removeDie(e.data.id)
 			break;
 		case "resize":
 			width = e.data.width
@@ -82,6 +82,9 @@ self.onmessage = (e) => {
 						// TODO: this won't work, need a die object
             rollDie(e.data.id)
             break;
+					case "removeDie":
+						removeDie(e.data.id)
+						break;
           case "stopSimulation":
             stopLoop = true
 						
@@ -425,9 +428,9 @@ const rollDie = (die) => {
 
 }
 
-const removeDie = (data) => {
+const removeDie = (id) => {
 	sleepingBodies = sleepingBodies.filter((die) => {
-		let match = die.id === data.id
+		let match = die.id === id
 		if(match){
 			// remove the mesh from the scene
 			physicsWorld.removeRigidBody(die)

--- a/src/components/world.offscreen.js
+++ b/src/components/world.offscreen.js
@@ -55,7 +55,7 @@ class WorldOffScreen {
 					this.onRollComplete()
 					break;
 				case 'die-removed':
-					this.onDieRemoved(e.data.die)
+					this.onDieRemoved(e.data.rollId)
 					break;
 			}
 		}

--- a/src/components/world.offscreen.js
+++ b/src/components/world.offscreen.js
@@ -49,11 +49,13 @@ class WorldOffScreen {
 					this.pendingThemePromises[e.data.id]()
 					break;
 				case 'roll-result':
-					const die = e.data.die
-					this.onRollResult(die)
+					this.onRollResult(e.data.die)
 					break;
 				case 'roll-complete':
 					this.onRollComplete()
+					break;
+				case 'die-removed':
+					this.onDieRemoved(e.data.die)
 					break;
 			}
 		}


### PR DESCRIPTION
This PR will fix a bunch of issues concerning the core methods `.roll()`, `.add()`, `.reroll()` and `.remove()`. 
These methods have been reworked to all accept `notation` as their first argument and an `options` object as their second argument. 
Roll and Add now accept the same notation and options argument. `groupId` argument is no longer needed for adding.
Reroll and Remove have been set up to accept an array of objects as an argument allowing for multiple rerolls/removals at once.
All four methods now return promises with a commonly formatted array of die objects as it's response.
Added `onRemoveComplete` callback
Fixed `.getRollResults()` so it's actually useful
I've resolved some theme assignment issues so themes can now be applied on a per die level, group level or box level.
Supporting 3d-dice modules also getting an update.
Notable data change, `die.result` has been changed to `die.value` to align with `group.value`
Big update to readme documentation with more details on how everything works.