### PR TITLE
Nonstandard die roll fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -180,7 +180,13 @@
 		"copy-dir": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
-			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw=="
+			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
+			"dev": true
+		},
+		"crypto-random": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/crypto-random/-/crypto-random-1.0.3.tgz",
+			"integrity": "sha1-wEF50c1kOfW1GhmZcnnyTdtIwgg="
 		},
 		"define-lazy-prop": {
 			"version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -183,11 +183,6 @@
 			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
 			"dev": true
 		},
-		"crypto-random": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/crypto-random/-/crypto-random-1.0.3.tgz",
-			"integrity": "sha1-wEF50c1kOfW1GhmZcnnyTdtIwgg="
-		},
 		"define-lazy-prop": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,10 @@
 		"@babylonjs/core": "^5.4.0",
 		"@babylonjs/loaders": "^5.4.0",
 		"@babylonjs/materials": "^5.4.0",
-		"copy-dir": "^1.3.0"
+		"crypto-random": "^1.0.3"
 	},
 	"devDependencies": {
+		"copy-dir": "^1.3.0",
 		"node-abort-controller": "^3.0.1",
 		"rollup-plugin-copy": "^3.4.0",
 		"rollup-plugin-visualizer": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
 	"dependencies": {
 		"@babylonjs/core": "^5.4.0",
 		"@babylonjs/loaders": "^5.4.0",
-		"@babylonjs/materials": "^5.4.0",
-		"crypto-random": "^1.0.3"
+		"@babylonjs/materials": "^5.4.0"
 	},
 	"devDependencies": {
 		"copy-dir": "^1.3.0",

--- a/src/components/Dice/Dice.js
+++ b/src/components/Dice/Dice.js
@@ -22,7 +22,7 @@ const defaultOptions = {
 // TODO: this would probably be better as a factory pattern
 class Dice {
   // mesh = null
-  result = 0
+  value = 0
   asleep = false
   constructor(options, scene) {
     this.config = {...defaultOptions, ...options}

--- a/src/components/offscreenCanvas.worker.js
+++ b/src/components/offscreenCanvas.worker.js
@@ -296,17 +296,24 @@ const remove = (data) => {
 	// check if this is d100 and remove associated d10 first
 	const dieData = dieCache[data.id]
 	if(dieData.hasOwnProperty('d10Instance')){
-		dieCache[dieData.d10Instance.id].mesh.dispose()
+		if(dieCache[dieData.d10Instance.id].mesh){
+			dieCache[dieData.d10Instance.id].mesh.dispose()
+
+			// remove d10 physics body just for d100 items
+			// The collider for other dice are removed at the WorldFacad level so it can be done in parallel
+			physicsWorkerPort.postMessage({
+				action: "removeDie",
+				id: dieData.d10Instance.id
+			})
+		}
 		delete dieCache[dieData.d10Instance.id]
-		physicsWorkerPort.postMessage({
-      action: "removeDie",
-			id: dieData.d10Instance.id
-    })
 		sleeperCount--
 	}
 
 	// remove die
-	dieData.mesh.dispose()
+	if(dieData.mesh) {
+		dieData.mesh.dispose()
+	}
 	// delete entry
 	delete dieCache[data.id]
 	// decrement count

--- a/src/components/offscreenCanvas.worker.js
+++ b/src/components/offscreenCanvas.worker.js
@@ -227,7 +227,10 @@ const addNonDie = (die) => {
 		config
 	}
 	dieCache[id] = newDie
-	handleAsleep(newDie)
+	
+	dieRollTimer.push(setTimeout(() => {
+		handleAsleep(newDie)
+	}, count++ * config.delay))
 }
 
 // add a die to the scene

--- a/src/components/offscreenCanvas.worker.js
+++ b/src/components/offscreenCanvas.worker.js
@@ -192,7 +192,10 @@ const clear = () => {
 	engine.stopRenderLoop()
 	// remove all dice
 	// dieCache.forEach(die => die.mesh.dispose())
-	Object.values(dieCache).forEach(die => die.mesh.dispose())
+	Object.values(dieCache).forEach(die => {
+		if(die.mesh)
+			die.mesh.dispose()
+	})
 
 	dieCache = {}
 	count = 0

--- a/src/components/offscreenCanvas.worker.js
+++ b/src/components/offscreenCanvas.worker.js
@@ -35,6 +35,9 @@ self.onmessage = (e) => {
     case "addDie":
 			add({...e.data.options})
       break
+    case "addNonDie":
+			addNonDie({...e.data.options})
+      break
 		case "loadTheme":
 			loadThemes(e.data.options)
 			break
@@ -210,6 +213,20 @@ const add = (options) => {
 	})
 }
 
+const addNonDie = (die) => {
+	if(engine.activeRenderLoops.length === 0) {
+		render(false)
+	}
+	const {id, value, ...config} = die
+	const newDie = {
+		id,
+		value,
+		config
+	}
+	dieCache[id] = newDie
+	handleAsleep(newDie)
+}
+
 // add a die to the scene
 const _add = async (options) => {
 	if(engine.activeRenderLoops.length === 0) {
@@ -345,9 +362,12 @@ const handleAsleep = async (die) => {
 	die.asleep = true
 
 	// get the roll result for this die
-	let result = await Dice.getRollResult(die, scene)
+	if(!die.value){
+		await Dice.getRollResult(die, scene)
+	}
+
 	// TODO: catch error if no result is found
-	if(result === undefined) {
+	if(die.value === undefined) {
 		console.log("No result. This die needs a reroll.")
 	}
 

--- a/src/components/world.offscreen.js
+++ b/src/components/world.offscreen.js
@@ -107,6 +107,10 @@ class WorldOffScreen {
 	add(options){
 		this.#OffscreenWorker.postMessage({action: "addDie", options})
 	}
+	
+	addNonDie(options){
+		this.#OffscreenWorker.postMessage({action: "addNonDie", options})
+	}
 
 	remove(options){
 		// remove the die from the render

--- a/src/components/world.onscreen.js
+++ b/src/components/world.onscreen.js
@@ -183,17 +183,18 @@ class WorldOnscreen {
 	}
 
 	addNonDie(die){
+		if(this.#engine.activeRenderLoops.length === 0) {
+			this.render(false)
+		}
+		const {id, value, ...config} = die
+		const newDie = {
+			id,
+			value,
+			config
+		}
+		this.#dieCache[id] = newDie
+		
 		this.#dieRollTimer.push(setTimeout(() => {
-			if(this.#engine.activeRenderLoops.length === 0) {
-				this.render(false)
-			}
-			const {id, value, ...config} = die
-			const newDie = {
-				id,
-				value,
-				config
-			}
-			this.#dieCache[id] = newDie
 			this.handleAsleep(newDie)
 		}, this.#count++ * this.config.delay))
 	}

--- a/src/components/world.onscreen.js
+++ b/src/components/world.onscreen.js
@@ -264,20 +264,25 @@ class WorldOnscreen {
 	// check if this is d100 and remove associated d10 first
 	if(dieData.hasOwnProperty('d10Instance')){
 		// remove die
-		this.#dieCache[dieData.d10Instance.id].mesh.dispose()
+		if(this.#dieCache[dieData.d10Instance.id].mesh){
+			this.#dieCache[dieData.d10Instance.id].mesh.dispose()
+
+			// remove d10 physics body just for d100 items
+			this.#physicsWorkerPort.postMessage({
+				action: "removeDie",
+				id: dieData.d10Instance.id
+			})
+		}
 		// delete entry
 		delete this.#dieCache[dieData.d10Instance.id]
-		// remove physics body
-		this.#physicsWorkerPort.postMessage({
-			action: "removeDie",
-			id: dieData.d10Instance.id
-    })
 		// decrement count
 		this.#sleeperCount--
 	}
 
 	// remove die
-	this.#dieCache[data.id].mesh.dispose()
+	if(this.#dieCache[data.id].mesh){
+		this.#dieCache[data.id].mesh.dispose()
+	}
 	// delete entry
 	delete this.#dieCache[data.id]
 	// decrement count

--- a/src/components/world.onscreen.js
+++ b/src/components/world.onscreen.js
@@ -158,7 +158,10 @@ class WorldOnscreen {
 		// stop anything that's currently rendering
 		this.#engine.stopRenderLoop()
 		// remove all dice
-		Object.values(this.#dieCache).forEach(die => die.mesh.dispose())
+		Object.values(this.#dieCache).forEach(die => {
+			if(die.mesh)
+				die.mesh.dispose()
+		})
 		
 		// reset storage
 		this.#dieCache = {}
@@ -177,6 +180,22 @@ class WorldOnscreen {
 				this.#add(resp)
 			}, this.#count++ * this.config.delay))
 		})
+	}
+
+	addNonDie(die){
+		this.#dieRollTimer.push(setTimeout(() => {
+			if(this.#engine.activeRenderLoops.length === 0) {
+				this.render(false)
+			}
+			const {id, value, ...config} = die
+			const newDie = {
+				id,
+				value,
+				config
+			}
+			this.#dieCache[id] = newDie
+			this.handleAsleep(newDie)
+		}, this.#count++ * this.config.delay))
 	}
 
 	// add a die to the scene
@@ -318,9 +337,12 @@ class WorldOnscreen {
 		die.asleep = true
 	
 		// get the roll result for this die
-		let result = await Dice.getRollResult(die, this.#scene)
+		if(!die.value){
+			await Dice.getRollResult(die, this.#scene)
+		}
+
 		// TODO: catch error if no result is found
-		if(result === undefined) {
+		if(die.value === undefined) {
 			console.log("No result. This die needs a reroll.")
 		}
 	

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -94,3 +94,28 @@ export const deepCopy = obj => JSON.parse(JSON.stringify(obj))
 export const sleeper = (ms) => {
   return new Promise(resolve => setTimeout(() => resolve(), ms));
 }
+
+export class Random {
+  /**
+   * Generate a random number between 0 (inclusive) and 1 (exclusive).
+   * A drop in replacement for Math.random()
+   * @return {number}
+   */
+  static value() {
+    const crypto = window.crypto || window.msCrypto;
+    const buffer = new Uint32Array(1);
+    const int = crypto.getRandomValues(buffer)[0];
+
+    return int / 2**32
+  }
+  /**
+   * Generate a very good random number between min (inclusive) and max (exclusive) by using crypto.getRandomValues() twice.
+   * @param  {number} min
+   * @param  {number} max
+   * @return {number}
+   */
+  static range(min, max) {
+    // return Math.floor(this.value() * (max - min) + min); // plain random
+    return (Math.floor(Math.pow(10,14)*this.value()*this.value())%(max-min+1))+min // super random!
+  }
+}


### PR DESCRIPTION
This PR will allow for non-standard die rolls to generate output despite not having a simulated 3D die to roll, such as a `d5` or `d16`.

To ensure the dice rolls are truly random I've implemented a function that uses two [crypto.getRandomValues()](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues) methods in order to create truly random numbers. In testing small batches of numbers, the spread of numbers is quite odd and non-uniform.

Non standard dice rolls can be combined with standard ones such as `1d4 + 1d5 + 1d6 + 1d7`