### PR TITLE
add configs for shadow and light intensity

### DIFF
--- a/src/WorldFacad.js
+++ b/src/WorldFacad.js
@@ -6,6 +6,8 @@ import { debounce, createAsyncQueue, Random } from './helpers'
 const defaultOptions = {
 	id: `dice-canvas-${Date.now()}`, // set the canvas id
   enableShadows: true, // do dice cast shadows onto DiceBox mesh?
+	shadowOpacity: .8,
+	lightIntensity: 1,
   delay: 10, // delay between dice being generated - 0 causes stuttering and physics popping
 	gravity: 2, // note: high gravity will cause dice piles to jiggle
 	startingHeight: 8, // height to drop the dice from - will not exceed the DiceBox height set by zoom

--- a/src/components/lights.js
+++ b/src/components/lights.js
@@ -9,13 +9,13 @@ const defaultOptions = {
 }
 
 function createLights(options = defaultOptions) {
-  const { enableShadows, scene } = options
+  const { enableShadows, shadowOpacity, intensity, scene } = options
   const d_light = new DirectionalLight("DirectionalLight", new Vector3(-0.3, -1, 0.4), scene)
   d_light.position = new Vector3(-50,65,-50)
-  d_light.intensity = .65
+  d_light.intensity = .65 * intensity
   
   const h_light = new HemisphericLight("HemisphericLight", new Vector3(1, 1, 0), scene)
-  h_light.intensity = .4
+  h_light.intensity = .4 * intensity
   
   if(enableShadows){
     d_light.shadowMinZ = 1
@@ -23,7 +23,7 @@ function createLights(options = defaultOptions) {
 		// d_light.autoCalcShadowZBounds = true
     d_light.shadowGenerator = new ShadowGenerator(2048, d_light);
     d_light.shadowGenerator.useCloseExponentialShadowMap = true; // best
-    d_light.shadowGenerator.darkness = .8
+    d_light.shadowGenerator.darkness = shadowOpacity
     // d_light.shadowGenerator.usePoissonSampling = true
     // d_light.shadowGenerator.bias = .01
   }

--- a/src/components/offscreenCanvas.worker.js
+++ b/src/components/offscreenCanvas.worker.js
@@ -77,7 +77,12 @@ const initScene = async (data) => {
 	engine = createEngine(canvas)
   scene = createScene({engine})
   camera = createCamera({engine})
-  lights = createLights({enableShadows: config.enableShadows})
+  lights = createLights({
+		enableShadows: config.enableShadows,
+		shadowOpacity: config.shadowOpacity,
+		intensity: config.lightIntensity,
+		scene
+	})
 
   // create the box that provides surfaces for shadows to render on
 	diceBox = new DiceBox({
@@ -128,6 +133,13 @@ const updateConfig = (options) => {
 		Object.values(dieCache).forEach(({mesh}) => {
 			mesh.scaling = new Vector3(config.scale,config.scale,config.scale)
 		})
+	}
+	if(prevConfig.shadowOpacity !== config.shadowOpacity) {
+		lights.directional.shadowGenerator.darkness = config.shadowOpacity
+	}
+	if(prevConfig.lightIntensity !== config.lightIntensity) {
+		lights.directional.intensity = .65 * config.lightIntensity
+		lights.hemispheric.intensity = .4 * config.lightIntensity
 	}
 }
 

--- a/src/components/world.onscreen.js
+++ b/src/components/world.onscreen.js
@@ -44,7 +44,12 @@ class WorldOnscreen {
 		this.#engine  = createEngine(this.#canvas )
 		this.#scene = createScene({engine:this.#engine })
 		this.#camera  = createCamera({engine:this.#engine, scene: this.#scene})
-		this.#lights  = createLights({enableShadows: this.config.enableShadows, scene: this.#scene})
+		this.#lights  = createLights({
+			enableShadows: this.config.enableShadows,
+			shadowOpacity: this.config.shadowOpacity,
+			intensity: this.config.lightIntensity,
+			scene: this.#scene
+		})
 	
 		// create the box that provides surfaces for shadows to render on
 		this.#diceBox  = new DiceBox({
@@ -88,12 +93,19 @@ class WorldOnscreen {
 		if(prevConfig.enableShadows !== this.config.enableShadows) {
 			// regenerate the lights
 			Object.values(this.#lights ).forEach(light => light.dispose())
-			this.#lights  = createLights({enableShadows: this.config.enableShadows})
+			this.#lights = createLights({enableShadows: this.config.enableShadows})
 		}
 		if(prevConfig.scale !== this.config.scale) {
 			Object.values(this.#dieCache).forEach(({mesh}) => {
 				mesh.scaling = new Vector3(this.config.scale,this.config.scale,this.config.scale)
 			})
+		}
+		if(prevConfig.shadowOpacity !== this.config.shadowOpacity) {
+			this.#lights.directional.shadowGenerator.darkness = this.config.shadowOpacity
+		}
+		if(prevConfig.lightIntensity !== this.config.lightIntensity) {
+			this.#lights.directional.intensity = .65 * this.config.lightIntensity
+			this.#lights.hemispheric.intensity = .4 * this.config.lightIntensity
 		}
 	}
 


### PR DESCRIPTION
Dial up or down the light intensity or the shadow alpha power.

The shadows are using [`useCloseExponentialShadowMap`](https://doc.babylonjs.com/divingDeeper/lights/shadows#close-exponential-shadow-map), so they do not turn completely black when shadow opacity is set to 0 due to bounce light.