### PR TITLE
Theme extends

### DIFF
--- a/src/WorldFacad.js
+++ b/src/WorldFacad.js
@@ -539,7 +539,6 @@ class WorldFacad {
 					this.#DiceWorld.addNonDie(roll)
 				} 
 				else {
-					console.log('diceInherited[roll.sides]', diceInherited[`d${roll.sides}`])
 					let parentTheme
 					if(diceExtra.includes(`d${roll.sides}`)) {
 						const parentThemeName = diceInherited[`d${roll.sides}`]

--- a/src/WorldFacad.js
+++ b/src/WorldFacad.js
@@ -527,6 +527,7 @@ class WorldFacad {
 
 				// TODO: eliminate the 'd' for more flexible naming such as 'fate' - ensure numbers are strings
 				if (roll.sides === 'fate' && (!diceAvailable.includes(`d${roll.sides}`) && !diceExtra.includes(`d${roll.sides}`))){
+					console.warn(`fate die unavailable in '${theme}' theme. Using fallback.`)
 					const min = -1
 					const max = 1
 					roll.value = Random.range(min,max)

--- a/src/WorldFacad.js
+++ b/src/WorldFacad.js
@@ -41,6 +41,7 @@ class WorldFacad {
 	onDieComplete = () => {}
 	onRollComplete = () => {}
 	onRemoveComplete = () => {}
+	onThemeLoaded = () => {}
 
   constructor(container, options = {}){
 		if(typeof options !== 'object') {
@@ -284,6 +285,12 @@ class WorldFacad {
 			}
 		}
 
+		if(themeData.hasOwnProperty('themeColor')){
+			this.updateConfig({
+				themeColor: themeData.themeColor
+			})
+		}
+
 		// if diceAvailable is not specified then assume the default set of seven
 		if(!themeData.hasOwnProperty('diceAvailable')){
 			themeData.diceAvailable = ['d4','d6','d8','d10','d12','d20','d100']
@@ -332,6 +339,8 @@ class WorldFacad {
 		// save the themeData for later
 		this.themesLoadedData[theme] = themeConfig
 
+		this.onThemeLoaded(themeConfig)
+
 		return themeConfig
 	}
 
@@ -340,13 +349,13 @@ class WorldFacad {
 	async updateConfig(options) {
 		const newConfig = {...this.config,...options}
 		// console.log('newConfig', newConfig)
-		// if(this.config.theme !== options.theme) {
-			await this.loadTheme(options.theme).then(config => {
+		if(options.theme && this.config.theme !== options.theme) {
+			await this.loadTheme(newConfig.theme).then(config => {
 				if(config.material.type !== 'color') {
 					newConfig.themeColor = undefined
 				}
 			}).catch(error => console.error(error))
-		// }
+		}
 
 		this.config = newConfig
 		// pass updates to DiceWorld

--- a/src/components/Dice.js
+++ b/src/components/Dice.js
@@ -109,6 +109,7 @@ class Dice {
     // can we get scene without passing it in?
     const {meshFilePath, meshName, scale} = options
     let has_d100 = false
+    let has_d10 = false
 
     //TODO: cache model files so it won't have to be fetched by other themes using the same models
     // using fetch to get modelData so we can pull out data unrelated to mesh importing
@@ -147,6 +148,9 @@ class Dice {
         if (!has_d100) {
           has_d100 = model.name === "d100"
         }
+        if (!has_d10) {
+          has_d10 = model.name === "d10"
+        }
         model.setEnabled(false)
         model.freezeNormals()
         model.freezeWorldMatrix()
@@ -156,7 +160,7 @@ class Dice {
         // model.id = meshName + '_' + model.id
         model.name = meshName + '_' + model.name
       })
-      if(!has_d100) {
+      if(!has_d100 && has_d10) {
         // console.log("create a d100 from a d10")  
         scene.getMeshByName(meshName + '_d10').clone(meshName + '_d100')
         scene.getMeshByName(meshName + '_d10_collider').clone(meshName + '_d100_collider')
@@ -190,15 +194,16 @@ class Dice {
   static async getRollResult(die,scene) {
     // TODO: Why a function in a function?? fix this
     const getDieRoll = (d=die) => new Promise((resolve,reject) => {
-      
-      const meshFaceIds = scene.colliderFaceMaps[die.config.meshName]
+
+      const meshName = die.config.parentMesh || die.config.meshName
+      const meshFaceIds = scene.colliderFaceMaps[meshName]
 
       if(!meshFaceIds[d.dieType]){
         throw new Error(`No colliderFaceMap data for ${d.dieType}`)
       }
 
       // const dieHitbox = d.config.scene.getMeshByName(`${d.dieType}_collider`).createInstance(`${d.dieType}-hitbox-${d.id}`)
-      const dieHitbox = scene.getMeshByName(`${die.config.meshName}_${d.dieType}_collider`).createInstance(`${die.config.meshName}_${d.dieType}-hitbox-${d.id}`)
+      const dieHitbox = scene.getMeshByName(`${meshName}_${d.dieType}_collider`).createInstance(`${meshName}_${d.dieType}-hitbox-${d.id}`)
       dieHitbox.isPickable = true
       dieHitbox.isVisible = true
       dieHitbox.setEnabled(true)

--- a/src/components/ThemeLoader.js
+++ b/src/components/ThemeLoader.js
@@ -40,6 +40,8 @@ class ThemeLoader {
     const {basePath, theme, material: matParams} = options
     //TODO: apply more matParams
     const diceMaterial = new StandardMaterial(theme, this.scene);
+
+    // TODO: make these methods reusable getDiffuseTexture(matParams, material)
     if(matParams.diffuseTexture){
       try {        
         diceMaterial.diffuseTexture = await this.importTextureAsync(`${basePath}/${matParams.diffuseTexture}`,theme)
@@ -112,6 +114,16 @@ class ThemeLoader {
         diceMatLight.bumpTexture = await this.importTextureAsync(`${basePath}/${matParams.bumpTexture}`,theme)
         if(matParams.bumpLevel){
           diceMatLight.bumpTexture.level = matParams.bumpLevel
+        }
+      } catch (error) {
+        console.error(error)
+      }
+    }
+    if(matParams.specularTexture){
+      try {        
+        diceMatLight.specularTexture = await this.importTextureAsync(`${basePath}/${matParams.specularTexture}`,theme)
+        if(matParams.specularPower){
+          diceMatLight.specularTexture.specularPower = matParams.specularPower
         }
       } catch (error) {
         console.error(error)

--- a/src/components/offscreenCanvas.worker.js
+++ b/src/components/offscreenCanvas.worker.js
@@ -176,12 +176,12 @@ const renderLoop = () => {
 }
 
 const loadThemes = async (options) => {
-	const {theme, basePath, material, meshFilePath, meshName} = options
+	const {theme, basePath, material, meshFilePath, meshName, d4FaceDown} = options
 	// load the textures and create the materials needed for this theme
 	await themeLoader.load({theme,basePath,material})
 
 	// Load the 3D meshes declared by the theme and return the collider mesh data to be passed on to the physics worker
-	const colliders = await Dice.loadModels({meshFilePath,meshName}, scene)
+	const colliders = await Dice.loadModels({meshFilePath,meshName,d4FaceDown}, scene)
 
 	if(!colliders){
 		throw new Error("No colliders returned from the 3D mesh file. Low poly colliders are expected to be in the same file as the high poly dice and the mesh name contains the word 'collider'")

--- a/src/components/offscreenCanvas.worker.js
+++ b/src/components/offscreenCanvas.worker.js
@@ -21,6 +21,7 @@ let
 	container,
 	themeLoader,
 	physicsWorkerPort,
+	meshList = {},
 	diceBufferView = new Float32Array(8000)
 
 // these are messages sent to this worker from World.js
@@ -181,19 +182,24 @@ const loadThemes = async (options) => {
 	await themeLoader.load({theme,basePath,material})
 
 	// Load the 3D meshes declared by the theme and return the collider mesh data to be passed on to the physics worker
-	const colliders = await Dice.loadModels({meshFilePath,meshName,d4FaceDown}, scene)
-
-	if(!colliders){
-		throw new Error("No colliders returned from the 3D mesh file. Low poly colliders are expected to be in the same file as the high poly dice and the mesh name contains the word 'collider'")
+	// don't load same models twice
+	if(!Object.keys(meshList).includes(meshName)){
+		meshList[meshName] = meshFilePath
+		const colliders = await Dice.loadModels({meshFilePath,meshName,d4FaceDown}, scene)
+		
+		if(!colliders){
+			throw new Error("No colliders returned from the 3D mesh file. Low poly colliders are expected to be in the same file as the high poly dice and the mesh name contains the word 'collider'")
+		}
+	
+		physicsWorkerPort.postMessage({
+			action: "loadModels",
+			options: {
+				colliders,
+				meshName
+			}
+		})
 	}
 
-	physicsWorkerPort.postMessage({
-		action: "loadModels",
-		options: {
-			colliders,
-			meshName
-		}
-	})
 	self.postMessage({action:"theme-loaded",id: theme})
 }
 

--- a/src/components/physics.worker.js
+++ b/src/components/physics.worker.js
@@ -172,16 +172,20 @@ const updateConfig = (options) => {
 const loadModels = async ({colliders: modelData, meshName}) => {
 
 	let has_d100 = false
+	let has_d10 = false
 
 	// turn our model data into convex hull items for the physics world
 	modelData.forEach((model,i) => {
 		colliders[meshName + '_' + model.name] = model
 		colliders[meshName + '_' + model.name].convexHull = createConvexHull(model)
+		if (!has_d10) {
+			has_d10 = model.id === "d10_collider"
+		}
 		if (!has_d100) {
 			has_d100 = model.id === "d100_collider"
 		}
 	})
-	if (!has_d100) {
+	if (!has_d100 && has_d10) {
 		colliders[`${meshName}_d100_collider`] = colliders[`${meshName}_d10_collider`]
 	}
 }
@@ -378,7 +382,7 @@ const addDie = (options) => {
 	const { sides, id, meshName, scale} = options
 	let cType = `d${sides}_collider`
 	const comboKey = `${meshName}_${cType}`
-	const colliderMass = colliders[comboKey].physicsMass || .1
+	const colliderMass = colliders[comboKey]?.physicsMass || .1
 	const mass = colliderMass * config.mass * config.scale // feature? mass should go up with scale, but it throws off the throwForce and spinForce scaling
 	// TODO: incorporate colliders physicsFriction and physicsRestitution settings
 	// clone the collider

--- a/src/components/world.onscreen.js
+++ b/src/components/world.onscreen.js
@@ -22,6 +22,7 @@ class WorldOnscreen {
 	#container
 	#themeLoader
 	#physicsWorkerPort
+	#meshList = {}
 	// onInitComplete = () => {}
 	onRollResult = () => {}
 	onRollComplete = () => {}
@@ -149,19 +150,24 @@ class WorldOnscreen {
 		await this.#themeLoader.load({theme,basePath,material})
 	
 		// Load the 3D meshes declared by the theme and return the collider mesh data to be passed on to the physics worker
-		const colliders = await Dice.loadModels({meshFilePath,meshName}, this.#scene)
+		// don't load same models twice
+		if(!Object.keys(this.#meshList).includes(meshName)){
+			this.#meshList[meshName] = meshFilePath
+			const colliders = await Dice.loadModels({meshFilePath,meshName}, this.#scene)
 
-		if(!colliders){
-			throw new Error("No colliders returned from the 3D mesh file. Low poly colliders are expected to be in the same file as the high poly dice and the mesh name contains the word 'collider'")
-		}
-	
-		this.#physicsWorkerPort.postMessage({
-			action: "loadModels",
-			options: {
-				colliders,
-				meshName
+			if(!colliders){
+				throw new Error("No colliders returned from the 3D mesh file. Low poly colliders are expected to be in the same file as the high poly dice and the mesh name contains the word 'collider'")
 			}
-		})
+		
+			this.#physicsWorkerPort.postMessage({
+				action: "loadModels",
+				options: {
+					colliders,
+					meshName
+				}
+			})
+		}
+
 		this.onThemeLoaded({id: theme})
 	}
 

--- a/src/components/world/scene.js
+++ b/src/components/world/scene.js
@@ -14,7 +14,7 @@ function createScene(options) {
   scene.pointerUpPredicate = () => false;
   scene.clearCachedVertexData();
   // used to map 3D mesh faces to actual dice values
-  scene.colliderFaceMaps = []
+  scene.themeData = {}
 
   const optimizationSettings = SceneOptimizerOptions.LowDegradationAllowed()
   optimizationSettings.optimizations = optimizationSettings.optimizations.splice(1)


### PR DESCRIPTION
Adding the ability to extend a theme. Like a JavaScript class, a theme that extends another will inherit the parent theme's dice.
fixing some loading and cache issues. Preventing mesh files with the same name from being reloaded
adding `themeColor` and `d4FaceDown` options to theme.config