### PR TITLE
Custom color fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,33 @@
 {
 	"name": "@3d-dice/dice-box",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@babylonjs/core": {
-			"version": "5.9.1",
-			"resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.9.1.tgz",
-			"integrity": "sha512-7gYujcwLKJX9n+QjUin7RHf+pJm7NZcASIosZZj+kzkJbPtdB0g2IrxG7mNH6lBU9n29IbhcJkBJS51Z8yvOZA==",
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.10.0.tgz",
+			"integrity": "sha512-xAfEYbYykHRwV633Q0rpbA+v/GpeBm7cVC2/YgwzcySJ5JYB/oAfx/MEKJX4PXIQctZ7SjipcE5HdnMh0H1F2g==",
 			"requires": {
 				"tslib": "^2.3.1"
 			}
 		},
 		"@babylonjs/loaders": {
-			"version": "5.9.1",
-			"resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.9.1.tgz",
-			"integrity": "sha512-gnY0TRoYQkDcXXi6VrocEDyR3ET8q59+r4x4KF5wKosZl+HSIjWW5/emmsl9DFR1N+nxY35KDzyGVtTnnrhviA==",
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.10.0.tgz",
+			"integrity": "sha512-n4pQvLyNiT8A08iWD44V/3WdA8I40D8auBrelbfeZ+dQh/4HGnPNkfFAfUrwS00HwP44ncl3DMJcbrYg/hdLog==",
 			"requires": {
-				"@babylonjs/core": "^5.9.1",
-				"babylonjs-gltf2interface": "^5.9.1",
+				"@babylonjs/core": "^5.10.0",
+				"babylonjs-gltf2interface": "^5.10.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@babylonjs/materials": {
-			"version": "5.9.1",
-			"resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-5.9.1.tgz",
-			"integrity": "sha512-YMYSR/pUYSTH7CkxpletLjsG0Lxb3wy5VQEHTfgAwZ0ysqAo7onVba0WTCSaK2cJ5Mdb2Q94J/P2zvDFGvtVKQ==",
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/@babylonjs/materials/-/materials-5.10.0.tgz",
+			"integrity": "sha512-aTtSbZe5Cfj52C5AAsPH4GSXevIVbqGOCgnoxUq1/9SiSi8Ak3yil7+JZD5XsCSht71+K5/ar4wuln9pXt22oA==",
 			"requires": {
-				"@babylonjs/core": "^5.9.1",
+				"@babylonjs/core": "^5.10.0",
 				"tslib": "^2.3.1"
 			}
 		},
@@ -110,9 +110,9 @@
 			"dev": true
 		},
 		"babylonjs-gltf2interface": {
-			"version": "5.9.1",
-			"resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.9.1.tgz",
-			"integrity": "sha512-GoZog+5WUDvxB/mUjU6DlqCzOTvZuiRW91/xBfKpIyC/729EK//bGzeeiXJJCSGlsdYqZqrCbnmpxMiuH4/IDQ=="
+			"version": "5.10.0",
+			"resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.10.0.tgz",
+			"integrity": "sha512-nW4CeC09wC8mSlD0IG4CoNnozhB71+dmJXtMuw4xS8WRXuJsFzWvFIwKXUiRpf2W4C/PIWcDjUwqRwZuk6BNKQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Frank Ali"
 	},
 	"description": "A 3D environment for rolling game dice",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"keywords": [
 		"3D",
 		"dice",
@@ -41,9 +41,9 @@
 		"postinstall": "node copyAssets.js"
 	},
 	"dependencies": {
-		"@babylonjs/core": "^5.9.1",
-		"@babylonjs/loaders": "^5.9.1",
-		"@babylonjs/materials": "^5.9.1",
+		"@babylonjs/core": "^5.10.0",
+		"@babylonjs/loaders": "^5.10.0",
+		"@babylonjs/materials": "^5.10.0",
 		"copy-dir": "^1.3.0",
 		"node-abort-controller": "^3.0.1"
 	},

--- a/src/WorldFacade.js
+++ b/src/WorldFacade.js
@@ -1,7 +1,6 @@
-import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { createCanvas } from './components/world/canvas'
 import physicsWorker from './components/physics.worker.js?worker&inline'
-import { debounce, createAsyncQueue, Random } from './helpers'
+import { debounce, createAsyncQueue, Random, hexToRGB } from './helpers'
 
 const defaultOptions = {
 	id: `dice-canvas-${Date.now()}`, // set the canvas id
@@ -503,8 +502,8 @@ class WorldFacade {
 			let colorSuffix = '', color
 
 			if(materialType === "color") {
-				color = Color3.FromHexString(themeColor)
-				colorSuffix = ((color.r*256*0.299 + color.g*256*0.587 + color.b*256*0.114) > 175) ? '_dark' : '_light'
+				color = hexToRGB(themeColor)
+				colorSuffix = ((color.r*0.299 + color.g*0.587 + color.b*0.114) > 186) ? '_dark' : '_light'
 			}
 
 			// TODO: should I validate that added dice are only joining groups of the same "sides" value - e.g.: d6's can only be added to groups when sides: 6? Probably.
@@ -553,8 +552,7 @@ class WorldFacade {
 						newStartPoint,
 						theme: parentTheme?.systemName || theme,
 						meshName: parentTheme?.meshName || meshName,
-						colorSuffix,
-						color
+						colorSuffix
 					})
 				}
 

--- a/src/components/Dice.js
+++ b/src/components/Dice.js
@@ -1,5 +1,6 @@
 import { SceneLoader } from '@babylonjs/core/Loading/sceneLoader'
 import { Vector3 } from '@babylonjs/core/Maths/math.vector'
+import { Color3 } from '@babylonjs/core/Maths/math.color'
 import { Ray } from "@babylonjs/core/Culling/ray";
 // import { RayHelper } from '@babylonjs/core/Debug';
 import '../helpers/babylonFileLoader'
@@ -41,8 +42,9 @@ class Dice {
     // create the instance
     const dieInstance = this.scene.getMeshByName(targetDie).createInstance(instanceName)
 
-    if(this.config.color){
-      dieInstance.instancedBuffers.customColor = this.config.color
+    if(this.config.colorSuffix.length > 0){
+      const color = Color3.FromHexString(this.config.themeColor)
+      dieInstance.instancedBuffers.customColor = color
     }
 
 		// start the instance under the floor, out of camera view

--- a/src/components/offscreenCanvas.worker.js
+++ b/src/components/offscreenCanvas.worker.js
@@ -12,10 +12,10 @@ self.onmessage = async (e) => {
       })
       break
     case "addDie":
-			WorldOffscreen.add({...e.data.options})
+			WorldOffscreen.add(e.data.options)
       break
     case "addNonDie":
-			WorldOffscreen.addNonDie({...e.data.options})
+			WorldOffscreen.addNonDie(e.data.options)
       break
 		case "loadTheme":
 			await WorldOffscreen.loadTheme(e.data.options).catch(error => console.error(error))

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -119,3 +119,41 @@ export class Random {
     return (Math.floor(Math.pow(10,14)*this.value()*this.value())%(max-min+1))+min // super random!
   }
 }
+
+// https://www.30secondsofcode.org/c/js-colors/p/1
+export const hexToRGB = hex => {
+  let alpha = false,
+    h = hex.slice(hex.startsWith('#') ? 1 : 0);
+  if (h.length === 3) h = [...h].map(x => x + x).join('');
+  else if (h.length === 8) alpha = true;
+  h = parseInt(h, 16);
+  let val = {
+    r: h >>> 16,
+    g: (h & 0x00ff00) >>> 8,
+    b: (h & 0x0000ff)
+  }
+  if(alpha) {
+    val.r = h >>> 24
+    val.g = (h & 0x00ff0000) >>> 16
+    val.b = (h & 0x0000ff00) >>> 8
+    val.a = (h & 0x000000ff)
+  }
+  return val
+
+};
+
+export const RGBToHSB = (r, g, b) => {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const v = Math.max(r, g, b),
+    n = v - Math.min(r, g, b);
+  const h =
+    n === 0 ? 0 : n && v === r ? (g - b) / n : v === g ? 2 + (b - r) / n : 4 + (r - g) / n;
+  return [60 * (h < 0 ? h + 6 : h), v && (n / v) * 100, v * 100];
+};
+
+export const hexToHSB = (hex) => {
+  const rgb = hexToRGB(hex)
+  return RGBToHSB(rgb.r,rgb.g,rgb.b)
+}


### PR DESCRIPTION
Custom color materials stopped working in offscreen canvas mode. This was happening because postMessage was cloning the `Color32` object down to a simple object, removing all the methods and object type required by the instancedBuffers.