### PR TITLE
Add the ability to use a seeded PRNG in the Physics Engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -763,6 +763,11 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"seedrandom": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+			"integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+		},
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@3d-dice/dice-box",
-	"version": "1.0.5",
+	"version": "1.1.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"name": "Frank Ali"
 	},
 	"description": "A 3D environment for rolling game dice",
-	"version": "1.0.5",
+	"version": "1.1.5",
 	"keywords": [
 		"3D",
 		"dice",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 		"@babylonjs/loaders": "^5.10.0",
 		"@babylonjs/materials": "^5.10.0",
 		"copy-dir": "^1.3.0",
-		"node-abort-controller": "^3.0.1"
+		"node-abort-controller": "^3.0.1",
+		"seedrandom": "^3.0.5"
 	},
 	"devDependencies": {
 		"rollup-plugin-copy": "^3.4.0",

--- a/src/WorldFacade.js
+++ b/src/WorldFacade.js
@@ -4,10 +4,10 @@ import { debounce, createAsyncQueue, Random, hexToRGB } from './helpers'
 
 const defaultOptions = {
 	id: `dice-canvas-${Date.now()}`, // set the canvas id
-  enableShadows: true, // do dice cast shadows onto DiceBox mesh?
+	enableShadows: true, // do dice cast shadows onto DiceBox mesh?
 	shadowTransparency: .8,
 	lightIntensity: 1,
-  delay: 10, // delay between dice being generated - 0 causes stuttering and physics popping
+	delay: 10, // delay between dice being generated - 0 causes stuttering and physics popping
 	scale: 5, // scale the dice
 	theme: 'default', // can be a hex color or a pre-defined theme such as 'purpleRock'
 	themeColor: '#2e8555', // used for color values or named theme variants - not fully implemented yet // green: #2e8555 // yellow: #feea03
@@ -15,7 +15,8 @@ const defaultOptions = {
 	assetPath: '/assets/dice-box/', // path to 'ammo', 'models', 'themes' folders and web workers
 	origin: location.origin,
 	meshFile: `models/default.json`,
-	suspendSimulation: false
+	suspendSimulation: false,
+	initialRNGSeed: null // Sets the initial RNG seed and turns on seeded random mode.
 }
 
 class WorldFacade {
@@ -34,17 +35,17 @@ class WorldFacade {
 	#DicePhysics
 	#dicePhysicsPromise
 	#dicePhysicsResolve
-	noop = () => {}
+	noop = () => { }
 
-  constructor(container, options = {}){
-		if(typeof options !== 'object') {
+	constructor(container, options = {}) {
+		if (typeof options !== 'object') {
 			throw new Error('Config options should be an object. Config reference: https://fantasticdice.games/docs/usage/config#configuration-options')
 		}
 		// pull out callback functions from options
 		const { onDieComplete, onRollComplete, onRemoveComplete, onThemeConfigLoaded, onThemeLoaded, ...boxOptions } = options
 
 		// extend defaults with options
-		this.config = {...defaultOptions, ...boxOptions}
+		this.config = { ...defaultOptions, ...boxOptions }
 
 		// assign callback functions
 		this.onDieComplete = options.onDieComplete || this.noop
@@ -55,16 +56,16 @@ class WorldFacade {
 
 
 		// if a canvas selector is provided then that will be used for the dicebox, otherwise a canvas will be created using the config.id
-    this.canvas = createCanvas({
-      selector: container,
-      id: this.config.id
-    })
+		this.canvas = createCanvas({
+			selector: container,
+			id: this.config.id
+		})
 		// create a queue to prevent theme being loaded multiple times
-		this.loadThemeQueue = createAsyncQueue({dedupe: true})
-  }
+		this.loadThemeQueue = createAsyncQueue({ dedupe: true })
+	}
 
 	// Load the BabylonJS World
-	async #loadWorld(){
+	async #loadWorld() {
 
 		// set up a promise to be fulfilled when a message comes back from DiceWorld indicating init is complete
 		this.#diceWorldPromise = new Promise((resolve, reject) => {
@@ -86,7 +87,7 @@ class WorldFacade {
 				onInitComplete
 			})
 		} else {
-			if(this.config.offscreen){
+			if (this.config.offscreen) {
 				console.warn("This browser does not support OffscreenCanvas. Using standard canvas fallback.")
 				this.config.offscreen = false
 			}
@@ -101,7 +102,7 @@ class WorldFacade {
 	}
 
 	// Load the AmmoJS physics world
-	#loadPhysics(){
+	#loadPhysics() {
 		// initialize physics world in which AmmoJS runs
 		this.#DicePhysics = new physicsWorker()
 		// set up a promise to be fulfilled when a message comes back from physics.worker indicating init is complete
@@ -109,11 +110,11 @@ class WorldFacade {
 			this.#dicePhysicsResolve = resolve
 		})
 		this.#DicePhysics.onmessage = (e) => {
-			switch( e.data.action ) {
+			switch (e.data.action) {
 				case "init-complete":
 					this.#dicePhysicsResolve() // fulfill promise so other things can run
 			}
-    }
+		}
 		// initialize the AmmoJS physics worker
 		this.#DicePhysics.postMessage({
 			action: "init",
@@ -123,29 +124,29 @@ class WorldFacade {
 		})
 	}
 
-	#connectWorld(){
+	#connectWorld() {
 		const channel = new MessageChannel()
-		
+
 		// create message channel for the visual world and the physics world to communicate through
 		this.#DiceWorld.connect(channel.port1)
 
 		// create message channel for this WorldFacade class to communicate with physics world
 		this.#DicePhysics.postMessage({
 			action: "connect"
-		},[ channel.port2 ])
+		}, [channel.port2])
 	}
 
-	resizeWorld(){
+	resizeWorld() {
 		// send resize events to workers - debounced for performance
 		const resizeWorkers = () => {
-			this.#DiceWorld.resize({width: this.canvas.clientWidth, height: this.canvas.clientHeight})
-			this.#DicePhysics.postMessage({action: "resize", width: this.canvas.clientWidth, height: this.canvas.clientHeight});
+			this.#DiceWorld.resize({ width: this.canvas.clientWidth, height: this.canvas.clientHeight })
+			this.#DicePhysics.postMessage({ action: "resize", width: this.canvas.clientWidth, height: this.canvas.clientHeight });
 		}
 		const debounceResize = debounce(resizeWorkers)
 		window.addEventListener("resize", debounceResize)
 	}
 
-  async init() {
+	async init() {
 		// trigger physics first so it can load in parallel with world
 		this.#loadPhysics()
 		await this.#loadWorld()
@@ -164,13 +165,13 @@ class WorldFacade {
 			// increment the completed roll count for this group
 			collection.completedRolls++
 			// if all rolls are completed then resolve the collection promise - returning dice that were in this collection
-			if(collection.completedRolls == collection.rolls.length) {
+			if (collection.completedRolls == collection.rolls.length) {
 				// pull out roll.collectionId and roll.id? They're meant to be internal values
-				collection.resolve(Object.values(collection.rolls).map(({collectionId, id, meshName, ...rest}) => rest))
+				collection.resolve(Object.values(collection.rolls).map(({ collectionId, id, meshName, ...rest }) => rest))
 			}
 
 			// trigger callback passing individual die result
-			const {collectionId, id, ...returnDie} = die
+			const { collectionId, id, ...returnDie } = die
 			this.onDieComplete(returnDie)
 		}
 		this.#DiceWorld.onRollComplete = () => {
@@ -198,14 +199,14 @@ class WorldFacade {
 			group.qty = groupData.rollsArray.length
 
 			// if all rolls are completed then resolve the collection promise - returning dice that were removed
-			if(collection.completedRolls == collection.rolls.length) {
-				collection.resolve(Object.values(collection.rolls).map(({id, ...rest}) => rest))
+			if (collection.completedRolls == collection.rolls.length) {
+				collection.resolve(Object.values(collection.rolls).map(({ id, ...rest }) => rest))
 			}
-			const {collectionId, id, removeCollectionId, meshName, ...returnDie} = die
+			const { collectionId, id, removeCollectionId, meshName, ...returnDie } = die
 			this.onRemoveComplete(returnDie)
 		}
 
-    // wait for both DiceWorld and DicePhysics to initialize
+		// wait for both DiceWorld and DicePhysics to initialize
 		await Promise.all([this.#diceWorldPromise, this.#dicePhysicsPromise])
 		// set up message channels between Dice World and Dice Physics
 
@@ -217,14 +218,14 @@ class WorldFacade {
 		//TODO: this should probably return a promise
 		// make this method chainable
 		return this
-  }
+	}
 
 	// fetch the theme config and return a themeData object
-	async getThemeConfig(theme){
+	async getThemeConfig(theme) {
 		const basePath = `${this.config.origin}${this.config.assetPath}themes/${theme}`
 		let themeData
 
-		if (theme === 'default'){
+		if (theme === 'default') {
 			// sensible defaults
 			themeData = {
 				name: "Default Colors",
@@ -244,11 +245,11 @@ class WorldFacade {
 		} else {
 			// fetch the theme.config file
 			themeData = await fetch(`${basePath}/theme.config.json`).then(resp => {
-				if(resp.ok) {
+				if (resp.ok) {
 					const contentType = resp.headers.get("content-type")
 					if (contentType && contentType.indexOf("application/json") !== -1) {
 						return resp.json()
-					} 
+					}
 					else if (resp.type && resp.type === 'basic') {
 						return resp.json()
 					}
@@ -264,31 +265,31 @@ class WorldFacade {
 
 		let meshFilePath = this.config.origin + this.config.assetPath + this.config.meshFile
 		let meshName = 'default'
-		if(!themeData){
+		if (!themeData) {
 			throw new Error("No theme config data to work with.")
 		}
-		if(themeData.hasOwnProperty('meshFile')){
+		if (themeData.hasOwnProperty('meshFile')) {
 			meshFilePath = `${basePath}/${themeData.meshFile}`
-			if(!themeData.hasOwnProperty('meshName')) {
+			if (!themeData.hasOwnProperty('meshName')) {
 				console.warn('You should provide a meshName in your theme.config.json file')
 				// fallback to fileName as meshName without extension
-				meshName = themeData.meshFile.replace(/(.*)\..{2,4}$/,'$1')
+				meshName = themeData.meshFile.replace(/(.*)\..{2,4}$/, '$1')
 			} else {
 				meshName = themeData.meshName
 			}
 		}
 
 		// if diceAvailable is not specified then assume the default set of seven
-		if(!themeData.hasOwnProperty('diceAvailable')){
-			themeData.diceAvailable = ['d4','d6','d8','d10','d12','d20','d100']
+		if (!themeData.hasOwnProperty('diceAvailable')) {
+			themeData.diceAvailable = ['d4', 'd6', 'd8', 'd10', 'd12', 'd20', 'd100']
 		}
 
-		if(themeData.hasOwnProperty("extends")){
+		if (themeData.hasOwnProperty("extends")) {
 			let target = this.themesLoadedData[themeData.extends]
-			if(!target){
+			if (!target) {
 				target = await this.loadTheme(themeData.extends).catch(error => console.error(error))
 			}
-			if(target){
+			if (target) {
 				themeData.diceInherited = [...(themeData.diceInherited || [])]
 				target.diceAvailable.map(die => {
 					themeData.diceInherited[die] = target.systemName
@@ -311,9 +312,9 @@ class WorldFacade {
 		return themeData
 	}
 
-	async loadTheme(theme){
+	async loadTheme(theme) {
 		// check the cache
-		if(this.themesLoadedData[theme]) {
+		if (this.themesLoadedData[theme]) {
 			// short circuit if theme has been previously loaded
 			// console.log(`${theme} has already been loaded. Returning cache`)
 			return this.themesLoadedData[theme]
@@ -324,7 +325,7 @@ class WorldFacade {
 		const themeConfig = this.themesLoadedData[theme] = await this.getThemeConfig(theme).catch(error => console.error(error))
 		this.onThemeConfigLoaded(themeConfig)
 
-		if(!themeConfig) return
+		if (!themeConfig) return
 
 		// pass config onto DiceWorld to load - the theme loader needs 'scene' from DiceWorld
 		await this.#DiceWorld.loadTheme(themeConfig).catch(error => console.error(error))
@@ -337,7 +338,7 @@ class WorldFacade {
 	// TODO: use getter and setter
 	// change config options
 	async updateConfig(options) {
-		const newConfig = {...this.config,...options}
+		const newConfig = { ...this.config, ...options }
 		// console.log('newConfig', newConfig)
 		const config = await this.loadThemeQueue.push(() => this.loadTheme(newConfig.theme))
 		// const themeData = config.at(-1) //get the last entry returned from the queue
@@ -367,12 +368,12 @@ class WorldFacade {
 		this.rollDiceData = {}
 		// clear all rendered die bodies
 		this.#DiceWorld.clear()
-    // clear all physics die bodies
-    this.#DicePhysics.postMessage({action: "clearDice"})
+		// clear all physics die bodies
+		this.#DicePhysics.postMessage({ action: "clearDice" })
 
 		// make this method chainable
 		return this
-  }
+	}
 
 	hide() {
 		this.canvas.style.display = 'none'
@@ -389,12 +390,12 @@ class WorldFacade {
 	}
 
 	// TODO: pass data with roll - such as roll name. Passed back at the end in the results
-	roll(notation, {theme, themeColor, newStartPoint = true} = {}) {
+	roll(notation, { theme, themeColor, newStartPoint = true } = {}) {
 		// note: to add to a roll on screen use .add method
 		// reset the offscreen worker and physics worker with each new roll
 		this.clear()
 		const collectionId = this.#collectionIndex++
-		
+
 		this.rollCollectionData[collectionId] = new Collection({
 			id: collectionId,
 			notation,
@@ -410,7 +411,7 @@ class WorldFacade {
 		return this.rollCollectionData[collectionId].promise
 	}
 
-  add(notation, {theme, themeColor, newStartPoint = true} = {}) {
+	add(notation, { theme, themeColor, newStartPoint = true } = {}) {
 
 		const collectionId = this.#collectionIndex++
 
@@ -421,32 +422,32 @@ class WorldFacade {
 			themeColor,
 			newStartPoint
 		})
-		
+
 		const parsedNotation = this.createNotationArray(notation)
 		this.#makeRoll(parsedNotation, collectionId)
 
 		// returns a Promise that is resolved in onRollComplete
 		return this.rollCollectionData[collectionId].promise
-  }
+	}
 
-	reroll(notation, {remove = false, hide = false, newStartPoint = true} = {}) {
+	reroll(notation, { remove = false, hide = false, newStartPoint = true } = {}) {
 		// TODO: add hide if you want to keep the die result for an external parser
 
 		// ensure notation is an array
 		const rollArray = Array.isArray(notation) ? notation : [notation]
 
 		// destructure out 'sides', 'theme', 'groupId', 'rollId' - basically just getting rid of value - could do ({value, ...rest}) => rest
-		const cleanNotation = rollArray.map(({value, ...rest}) => rest)
+		const cleanNotation = rollArray.map(({ value, ...rest }) => rest)
 
-		if(remove === true){
-			this.remove(cleanNotation, {hide})
+		if (remove === true) {
+			this.remove(cleanNotation, { hide })
 		}
 
 		// .add will return a promise that will then be returned here
-		return this.add(cleanNotation, {newStartPoint})
+		return this.add(cleanNotation, { newStartPoint })
 	}
 
-	remove(notation, {hide = false} = {}) {
+	remove(notation, { hide = false } = {}) {
 		// ensure notation is an array
 		const rollArray = Array.isArray(notation) ? notation : [notation]
 
@@ -466,23 +467,23 @@ class WorldFacade {
 			// die.id = this.rollDiceData[die.rollId].id - note: can appear in async roll result data if attached to die object
 			let id = this.rollDiceData[die.rollId].id
 			// remove the die from the render - don't like having to pass two ids. rollId is passed over just so it can be passed back for callback
-			this.#DiceWorld.remove({id,rollId: die.rollId})
+			this.#DiceWorld.remove({ id, rollId: die.rollId })
 			// remove the die from the physics bodies
-			this.#DicePhysics.postMessage({action: "removeDie", id })
+			this.#DicePhysics.postMessage({ action: "removeDie", id })
 		})
 
 		return this.rollCollectionData[collectionId].promise
 	}
 
 	// used by both .add and .roll - .roll clears the box and .add does not
-	async #makeRoll(parsedNotation, collectionId){
+	async #makeRoll(parsedNotation, collectionId) {
 
 		const collection = this.rollCollectionData[collectionId]
 		let newStartPoint = collection.newStartPoint
 
 		// loop through the number of dice in the group and roll each one
 		parsedNotation.forEach(async notation => {
-			if(!notation.sides) {
+			if (!notation.sides) {
 				throw new Error("Improper dice notation or unable to parse notation")
 			}
 			const theme = notation.theme || collection.theme || this.config.theme
@@ -491,20 +492,20 @@ class WorldFacade {
 			const hasGroupId = notation.groupId !== undefined
 			let index
 
-			
+
 			// load the theme, will be short circuited if previously loaded
 			const loadTheme = () => this.loadTheme(theme)
 			await this.loadThemeQueue.push(loadTheme)
 
-			const {meshName, diceAvailable, diceInherited = {}, material: { type: materialType }} = this.themesLoadedData[theme]
+			const { meshName, diceAvailable, diceInherited = {}, material: { type: materialType } } = this.themesLoadedData[theme]
 			const diceExtra = Object.keys(diceInherited)
 
 			let colorSuffix = '', color
 
-			if(materialType === "color") {
+			if (materialType === "color") {
 				color = hexToRGB(themeColor)
 				// dat.gui uses HSB(a.k.a HSV) brightness greater than .5 and saturation less than .5
-				colorSuffix = ((color.r*0.299 + color.g*0.587 + color.b*0.114) > 175) ? '_dark' : '_light'
+				colorSuffix = ((color.r * 0.299 + color.g * 0.587 + color.b * 0.114) > 175) ? '_dark' : '_light'
 			}
 
 			// TODO: should I validate that added dice are only joining groups of the same "sides" value - e.g.: d6's can only be added to groups when sides: 6? Probably.
@@ -530,21 +531,21 @@ class WorldFacade {
 				collection.rolls.push(this.rollDiceData[rollId])
 
 				// TODO: eliminate the 'd' for more flexible naming such as 'fate' - ensure numbers are strings
-				if (roll.sides === 'fate' && (!diceAvailable.includes(`d${roll.sides}`) && !diceExtra.includes(`d${roll.sides}`))){
+				if (roll.sides === 'fate' && (!diceAvailable.includes(`d${roll.sides}`) && !diceExtra.includes(`d${roll.sides}`))) {
 					console.warn(`fate die unavailable in '${theme}' theme. Using fallback.`)
 					const min = -1
 					const max = 1
-					roll.value = Random.range(min,max)
+					roll.value = Random.range(min, max)
 					this.#DiceWorld.addNonDie(roll)
-				} else if(this.config.suspendSimulation || (!diceAvailable.includes(`d${roll.sides}`) && !diceExtra.includes(`d${roll.sides}`))){
+				} else if (this.config.suspendSimulation || (!diceAvailable.includes(`d${roll.sides}`) && !diceExtra.includes(`d${roll.sides}`))) {
 					// check if the requested roll is available in the current theme, if not then use crypto fallback
 					console.warn(this.config.suspendSimulation ? "3D simulation suspended. Using fallback." : `${roll.sides} sided die unavailable in '${theme}' theme. Using fallback.`)
 					roll.value = Random.range(1, roll.sides)
 					this.#DiceWorld.addNonDie(roll)
-				} 
+				}
 				else {
 					let parentTheme
-					if(diceExtra.includes(`d${roll.sides}`)) {
+					if (diceExtra.includes(`d${roll.sides}`)) {
 						const parentThemeName = diceInherited[`d${roll.sides}`]
 						parentTheme = this.themesLoadedData[parentThemeName]
 					}
@@ -561,7 +562,7 @@ class WorldFacade {
 				newStartPoint = false
 			}
 
-			if(hasGroupId) {
+			if (hasGroupId) {
 				Object.assign(this.rollGroupData[index].rolls, rolls)
 			} else {
 				// save this roll group for later
@@ -577,16 +578,16 @@ class WorldFacade {
 	// accepts array of notations eg: ['4d6','2d10']
 	// accepts object {sides:int, qty:int}
 	// accepts array of objects eg: [{sides:int, qty:int, mods:[]}]
-	createNotationArray(input){
-		const notation = Array.isArray( input ) ? input : [ input ]
+	createNotationArray(input) {
+		const notation = Array.isArray(input) ? input : [input]
 		let parsedNotation = []
 
 
-		const verifyObject = ( object ) => {
-			if(!object.hasOwnProperty('qty')) {
+		const verifyObject = (object) => {
+			if (!object.hasOwnProperty('qty')) {
 				object.qty = 1
 			}
-			if ( object.hasOwnProperty('sides') ) {
+			if (object.hasOwnProperty('sides')) {
 				return true
 			} else {
 				const err = "Roll notation is missing sides"
@@ -597,7 +598,7 @@ class WorldFacade {
 		const incrementId = (key) => {
 			key = key.toString()
 			let splitKey = key.split(".")
-			if(splitKey[1]){
+			if (splitKey[1]) {
 				splitKey[1] = parseInt(splitKey[1]) + 1
 			} else {
 				splitKey[1] = 1
@@ -607,9 +608,9 @@ class WorldFacade {
 
 		// verify that the rollId is unique. If not then increment it by .1
 		// rollIds become keys in the rollDiceData object, so they must be unique or they will overwrite another entry
-		const verifyRollId = ( object ) => {
-			if(object.hasOwnProperty('rollId')){
-				if(this.rollDiceData.hasOwnProperty(object.rollId)){
+		const verifyRollId = (object) => {
+			if (object.hasOwnProperty('rollId')) {
+				if (this.rollDiceData.hasOwnProperty(object.rollId)) {
 					object.rollId = incrementId(object.rollId)
 				}
 			}
@@ -619,88 +620,88 @@ class WorldFacade {
 		notation.forEach(roll => {
 			// console.log('roll', roll)
 			// if notation is an array of strings
-			if ( typeof roll === 'string' ) {
-				parsedNotation.push( this.parse( roll ) )
-			} else if ( typeof notation === 'object' ) {
-				verifyRollId( roll )
-				verifyObject( roll )  && parsedNotation.push( roll )
+			if (typeof roll === 'string') {
+				parsedNotation.push(this.parse(roll))
+			} else if (typeof notation === 'object') {
+				verifyRollId(roll)
+				verifyObject(roll) && parsedNotation.push(roll)
 			}
 		})
 
 		return parsedNotation
 	}
 
-  // parse text die notation such as 2d10+3 => {number:2, type:6, modifier:3}
-  // taken from https://github.com/ChapelR/dice-notation
-  parse(notation) {
-    const diceNotation = /(\d+)[dD](\d+)(.*)$/i
+	// parse text die notation such as 2d10+3 => {number:2, type:6, modifier:3}
+	// taken from https://github.com/ChapelR/dice-notation
+	parse(notation) {
+		const diceNotation = /(\d+)[dD](\d+)(.*)$/i
 		const percentNotation = /(\d+)[dD]([0%]+)(.*)$/i
 		const fudgeNotation = /(\d+)df+(ate)*$/i
-    const modifier = /([+-])(\d+)/
-    const cleanNotation = notation.trim().replace(/\s+/g, '')
-    const validNumber = (n, err) => {
-      n = Number(n)
-      if (Number.isNaN(n) || !Number.isInteger(n) || n < 1) {
-        throw new Error(err);
-      }
-      return n
-    }
-
-		// match percentNotation before diceNotation
-    const roll = cleanNotation.match(percentNotation) || cleanNotation.match(diceNotation) || cleanNotation.match(fudgeNotation);
-
-		let mod = 0;
-    const msg = 'Invalid notation: ' + notation + '';
-
-    if (!roll || !roll.length || roll.length < 3) {
-      throw new Error(msg);
-    }
-    if (roll[3] && modifier.test(roll[3])) {
-      const modParts = roll[3].match(modifier);
-      let basicMod = validNumber(modParts[2], msg);
-      if (modParts[1].trim() === '-') {
-        basicMod *= -1;
-      }
-      mod = basicMod;
-    }
-
-		const returnObj = {
-			qty : validNumber(roll[1], msg),
-      modifier: mod,
+		const modifier = /([+-])(\d+)/
+		const cleanNotation = notation.trim().replace(/\s+/g, '')
+		const validNumber = (n, err) => {
+			n = Number(n)
+			if (Number.isNaN(n) || !Number.isInteger(n) || n < 1) {
+				throw new Error(err);
+			}
+			return n
 		}
 
-		if(cleanNotation.match(percentNotation)){
+		// match percentNotation before diceNotation
+		const roll = cleanNotation.match(percentNotation) || cleanNotation.match(diceNotation) || cleanNotation.match(fudgeNotation);
+
+		let mod = 0;
+		const msg = 'Invalid notation: ' + notation + '';
+
+		if (!roll || !roll.length || roll.length < 3) {
+			throw new Error(msg);
+		}
+		if (roll[3] && modifier.test(roll[3])) {
+			const modParts = roll[3].match(modifier);
+			let basicMod = validNumber(modParts[2], msg);
+			if (modParts[1].trim() === '-') {
+				basicMod *= -1;
+			}
+			mod = basicMod;
+		}
+
+		const returnObj = {
+			qty: validNumber(roll[1], msg),
+			modifier: mod,
+		}
+
+		if (cleanNotation.match(percentNotation)) {
 			returnObj.sides = '100' // as string, not number
-		} else if(cleanNotation.match(fudgeNotation)){
+		} else if (cleanNotation.match(fudgeNotation)) {
 			returnObj.sides = 'fate' // force lowercase
 		} else {
 			returnObj.sides = validNumber(roll[2], msg);
 		}
 
-    return returnObj
-  }
+		return returnObj
+	}
 
 	#parseGroup(groupId) {
 		// console.log('groupId', groupId)
 		const rollGroup = this.rollGroupData[groupId]
 		// turn object into an array
-		const rollsArray = Object.values(rollGroup.rolls).map(({collectionId, id, meshName, ...rest}) => rest)
+		const rollsArray = Object.values(rollGroup.rolls).map(({ collectionId, id, meshName, ...rest }) => rest)
 		// add up the values
 		// some dice may still be rolling, should this be a promise?
 		// if dice are still rolling in the group then the value is undefined - hence the isNaN check
-		let value = rollsArray.reduce((val,roll) => {
+		let value = rollsArray.reduce((val, roll) => {
 			const rollVal = isNaN(roll.value) ? 0 : roll.value
 			return val + rollVal
-		},0)
+		}, 0)
 		// add the modifier
 		value += rollGroup.modifier ? rollGroup.modifier : 0
 		// return the value and the rollsArray
-		return {value, rollsArray}
+		return { value, rollsArray }
 	}
 
-	getRollResults(){
+	getRollResults() {
 		// loop through each roll group
-		return Object.entries(this.rollGroupData).map(([key,val]) => {
+		return Object.entries(this.rollGroupData).map(([key, val]) => {
 			// parse the group data to get the value and the rolls as an array
 			const groupData = this.#parseGroup(key)
 			// set the value for this roll group in this.rollGroupData
@@ -708,22 +709,31 @@ class WorldFacade {
 			// set the qty equal to the number of rolls - this can be changed by rerolls and removals
 			val.qty = groupData.rollsArray.length
 			// copy the group that will be put into the return object
-			const groupCopy = {...val}
+			const groupCopy = { ...val }
 			// replace the rolls object with a rolls array
 			groupCopy.rolls = groupData.rollsArray
 			// return the groupCopy - note: we never return this.rollGroupData
 			return groupCopy
 		})
 	}
+
+	// Sets the random seed on the seeded random number generator in the physics worker.
+	setRandomSeed(seed) {
+		this.#DicePhysics.postMessage({action: "setRandomSeed", seed});
+	}
+
+	disableSeededRandom() {
+		this.#DicePhysics.postMessage({action: "disableSeededRandom"});
+	}
 }
 
-class Collection{
-	constructor(options){
-		Object.assign(this,options)
+class Collection {
+	constructor(options) {
+		Object.assign(this, options)
 		this.rolls = options.rolls || []
 		this.completedRolls = 0
 		const that = this
-		this.promise = new Promise((resolve,reject) => {
+		this.promise = new Promise((resolve, reject) => {
 			that.resolve = resolve
 			that.reject = reject
 		})

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -6,45 +6,45 @@ import { Vector3 } from '@babylonjs/core/Maths/math.vector'
 import { ShadowOnlyMaterial } from '@babylonjs/materials/shadowOnly/shadowOnlyMaterial'
 
 const defaultOptions = {
-  aspect: 300 / 150,
-  enableDebugging: false,
-  enableShadows: true,
+	aspect: 300 / 150,
+	enableDebugging: false,
+	enableShadows: true,
 }
 
-class Container{
+class Container {
 	size = 9.5
-	constructor(options){
-		this.config = {...defaultOptions, ...options}
+	constructor(options) {
+		this.config = { ...defaultOptions, ...options }
 		this.create()
 	}
-	create(options){
+	create(options) {
 		// remove any previously existing boxes
 		this.destroy()
 		// extend config with options on create
-		Object.assign(this.config,options)
+		Object.assign(this.config, options)
 		const { aspect, enableDebugging = true, enableShadows } = this.config
 		const wallHeight = 30
 		let boxMaterial
 
 		this.box = new TransformNode("diceBox");
 
-		if(enableDebugging) {
+		if (enableDebugging) {
 			boxMaterial = new StandardMaterial("diceBox_material")
 			boxMaterial.alpha = .7
 			boxMaterial.diffuseColor = new Color3(1, 1, 0);
 		}
 		else {
-			if(enableShadows) {
-				boxMaterial = new ShadowOnlyMaterial('shadowOnly',this.config.scene)
+			if (enableShadows) {
+				boxMaterial = new ShadowOnlyMaterial('shadowOnly', this.config.scene)
 				// boxMaterial.alpha = 1
 				// boxMaterial.diffuseColor = new Color3(1, 1, 1)
 				// boxMaterial.activeLight = lights.directional
-			} 
+			}
 		}
 
 		// Bottom of the Box
-		const ground = CreateBox("ground",{
-			width: this.size * 2, 
+		const ground = CreateBox("ground", {
+			width: this.size * 2,
 			height: 1,
 			depth: this.size * 2
 		}, this.config.scene)
@@ -53,9 +53,9 @@ class Container{
 		ground.receiveShadows = true
 		ground.setParent(this.box)
 
-		if(enableDebugging) {
+		if (enableDebugging) {
 			// North Wall
-			const wallTop = CreateBox("wallTop",{
+			const wallTop = CreateBox("wallTop", {
 				width: this.size,
 				height: wallHeight,
 				depth: 1
@@ -68,11 +68,11 @@ class Container{
 			wallTop.setParent(this.box)
 
 			// Right Wall
-			const wallRight = CreateBox("wallRight",{
-				width: 1, 
+			const wallRight = CreateBox("wallRight", {
+				width: 1,
 				height: wallHeight,
 				depth: this.size
-			}, this.config.scene )
+			}, this.config.scene)
 			wallRight.position.x = this.size * aspect / 2
 			wallRight.position.y = wallHeight / 2
 			wallRight.material = boxMaterial
@@ -80,8 +80,8 @@ class Container{
 			wallRight.setParent(this.box)
 
 			// South Wall
-			const wallBottom = CreateBox("wallBottom",{
-				width: this.size, 
+			const wallBottom = CreateBox("wallBottom", {
+				width: this.size,
 				height: wallHeight,
 				depth: 1
 			}, this.config.scene)
@@ -93,8 +93,8 @@ class Container{
 			wallBottom.setParent(this.box)
 
 			// Left Wall
-			const wallLeft = CreateBox("wallLeft",{
-				width: 1, 
+			const wallLeft = CreateBox("wallLeft", {
+				width: 1,
 				height: wallHeight,
 				depth: this.size
 			}, this.config.scene)
@@ -105,8 +105,8 @@ class Container{
 			wallLeft.setParent(this.box)
 		}
 	}
-	destroy(){
-		if(this.box) {
+	destroy() {
+		if (this.box) {
 			this.box.dispose()
 		}
 	}

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,16 +5,16 @@ const copy = require('rollup-plugin-copy')
 
 module.exports = defineConfig({
 	base: process.env.NODE_ENV === 'production' ? './' : './src',
-  build: {
-    lib: {
-      entry: path.resolve(__dirname, 'src/index.js'),
-      name: 'dice-box',
-      fileName: (format) => `dice-box.${format}.js`
-    },
+	build: {
+		lib: {
+			entry: path.resolve(__dirname, 'src/index.js'),
+			name: 'dice-box',
+			fileName: (format) => `dice-box.${format}.js`
+		},
 		assetsDir: 'assets/dice-box',
-    rollupOptions: {
+		rollupOptions: {
 			preserveEntrySignatures: "allow-extension",
-      input: {
+			input: {
 				main: path.resolve(__dirname, 'src/index.js')
 			},
 			output: [{
@@ -44,6 +44,6 @@ module.exports = defineConfig({
 				// 	brotliSize: true
 				// })
 			]
-    },
-  }
+		},
+	}
 })


### PR DESCRIPTION
Testing out the idea I had over in #47 on the source repo, I've added some code which makes the random number generator in the physics worker deterministic.

Here's what I've determined so far:

* Fixed canvas sizes do not impact the simulation, even if those canvases are of different sizes.
* Display resolution does not impact the simulation.
* Making the canvas the same size as the viewport (to toss dice on top of the whole page, for example) _does_ impact the simulation when you change the viewport size quite drastically.
* Changing the _scale_ of the dice does impact the physics (which makes sense, though for my case of synching clients, I don't think there's a case where you'd have different scales on different clients).
* _Sometimes_ something goes sideways and 2 canvas elements that are otherwise identical do not produce the same results. It's the same probably about 70% of the time, and I'm thinking it has something to do with either the timing on the main loop, something weird happening with floating point math, or some randomness in the rigidbody physics (somewhere in Ammo that I likely won't be able to get to).
* Interestingly, the _first_ roll after the world is initialized is _always_ identical for a given seed - I've not been able to get it to give different results right after initialization.