### PR TITLE
Add type:module to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,16 @@
   "bugs": {
     "url": "https://github.com/3d-dice/dice-box/issues"
   },
+  "type": "module",
   "files": [
     "dist",
     "copyAssets.js"
   ],
   "main": "./dist/dice-box.es.js",
-  "dev-files": [
+  "files-dev": [
     "src"
   ],
-  "dev-main": "./src/index",
+  "main-dev": "./src/index",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
According to Stack Overflow thread: https://stackoverflow.com/questions/57492546/what-is-the-difference-between-js-and-mjs-files

> Node.js will treat `.cjs` files as CommonJS modules and `.mjs` files as ECMAScript modules. It will treat `.js` files as whatever the default module system for the project is (which is CommonJS unless package.json says `"type": "module",`).

Also, this thread had a good explanation concerning different version of nodejs: https://stackoverflow.com/questions/61401475/why-is-type-module-in-package-json-file

So I think all I need to add is `"type": "module"`. I don't believe I need to rename the files to a `.mjs` extension.

fixes #77 